### PR TITLE
Add signing configs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,27 @@ android {
 
         buildConfigField "String", "API_URL", '"http://localhost"'
     }
+
+    signingConfigs {
+        release {
+            try {
+                storeFile file(RELEASE_KEY_STORE_PATH)
+                storePassword RELEASE_KEYSTORE_PASSWORD
+                keyAlias RELEASE_KEY_ALIAS
+                keyPassword RELEASE_KEY_PASSWORD
+            }
+            catch (ex) {
+                println(ex.getMessage())
+                throw new InvalidUserDataException("Ensrure RELEASE_KEYSTORE_PASSWORD and RELEASE_KEY_PASSWORD are defined in gradle.properties.")
+            }
+        }
+
+    }
+
     buildTypes {
         release {
             minifyEnabled false
+            signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField "String", "API_URL", '"http://my-real-api.com"'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,8 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+RELEASE_KEYSTORE_PASSWORD=PUT_KEYSTORE_PASSWORD_HERE
+RELEASE_KEY_PASSWORD=PUT_KEY_PASSWORD_HERE
+RELEASE_KEY_ALIAS =PUT_KEYSTORE_ALIAS_HERE
+RELEASE_KEY_STORE_PATH=PUT_PATH_TO_KEYSTORE_HERE


### PR DESCRIPTION
This will allows us to build and sign the APK via gradle. You need to setup your details correctly in the gradle.properties file
